### PR TITLE
fix: keep global.location shim for mocha

### DIFF
--- a/src/karma.js
+++ b/src/karma.js
@@ -120,7 +120,6 @@ export default class KarmaClient extends EventEmitter {
 	removeShims(scriptUrl) {
 		if (scriptUrl.indexOf('mocha') !== -1) {
 			delete global.window;
-			delete global.location;
 		}
 	}
 


### PR DESCRIPTION
Mocha accesses `global.location` during runtime so we need keep this shim.