### PR TITLE
fix: add shims for jasmine

### DIFF
--- a/src/karma.js
+++ b/src/karma.js
@@ -109,16 +109,21 @@ export default class KarmaClient extends EventEmitter {
 	}
 
 	applyShims(scriptUrl) {
-		if (scriptUrl.indexOf('mocha') !== -1) {
+		if (scriptUrl.includes('mocha')) {
 			global.window = global;
 			global.location = {
 				pathname: '/'
+			};
+		} else if (scriptUrl.includes('jasmine')) {
+			global.window = global;
+			global.location = {
+				origin: 'null'
 			};
 		}
 	}
 
 	removeShims(scriptUrl) {
-		if (scriptUrl.indexOf('mocha') !== -1) {
+		if (scriptUrl.includes('mocha')) {
 			delete global.window;
 		}
 	}


### PR DESCRIPTION
the latest version of karma-jasmine accesses window.location for failed tests