### PR TITLE
fix(android): harden emulator check

### DIFF
--- a/src/karma.js
+++ b/src/karma.js
@@ -258,7 +258,7 @@ export default class KarmaClient extends EventEmitter {
 			}
 		}
 
-		if (Ti.Platform.model.toLowerCase().indexOf('sdk') !== -1) {
+		if (/sdk|emulator/i.test(Ti.Platform.model)) {
 			if ([ 'localhost', '127.0.0.1' ].indexOf(hostname) !== -1) {
 				hostname = '10.0.2.2';
 				host = port ? `${hostname}:${port}` : hostname;


### PR DESCRIPTION
We've seen that `Ti.Platform.model` can return two values:
* Android SDK built for x86
* AOSP on IA Emulator

So harden the emulator check to allow for either of those